### PR TITLE
Properly hande ENOENT errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+
+indent_style = space
+indent_size = 2
+
+max_line_length = 80
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
If there's something wrong with the config, a 'Failed to run undefined' is thrown, which is confusing to users.

I changed it to show 'Failed to run Markdown Lint' and I've also throttled it to only show once.

Maybe adding a timer or something (show once every 5 minutes or so) would be better, but that's up to you :wink: 