### PR TITLE
Add language_markdown's grammar 'text.md' to scope

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ export function provideLinter() {
     name: 'markdownlint',
     scope: 'file',
     lintsOnChange: false,
-    grammarScopes: ['source.gfm', 'source.pfm'],
+    grammarScopes: ['source.gfm', 'source.pfm', 'text.md'],
     lint(textEditor) {
       const editorPath = textEditor.getPath();
       const cwd = atom.project.relativizePath(editorPath)[0];


### PR DESCRIPTION
This adds another common markdown grammar to the [*grammarScopes* in *index.js*](https://github.com/leonelgalan/linter-markdownlint/blob/16c0c98e0789fbc9ca9fd4399197f887547d1c37/lib/index.js#L98). The inserted grammar is introduced by the package [lanugage-markdown](https://github.com/burodepeper/language-markdown) which appears to be quite popular among the Atom community (361.504 downloads as of 02.02.2020). This package is meant to replace the default markdown package *language-gfm*, which means most of the people using it, would not be able to benefit from  *linter-markdownlint*. This PR just adds the *lanugage-markdown* grammar `text.md` in addition to the already included markdown grammars.